### PR TITLE
Safer replacements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,10 +43,18 @@ endmacro(add_tooling_executable)
 # debug executable, for development
 if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
   add_tooling_executable(explorer src/explorer.cpp)
+  add_tooling_executable(ciexplorer src/ciexplorer.cpp)
 endif()
 
 # actual applications
-add_tooling_executable(minifier src/main.cpp src/format/minifyFormat.cpp src/actions/minifyAction.cpp src/actions/PPSymbolsAction.cpp)
+add_tooling_executable(
+  minifier
+  src/main.cpp
+  src/format/minifyFormat.cpp
+  src/actions/minifyAction.cpp
+  src/actions/PPSymbolsAction.cpp
+  src/actions/expandMacroAction.cpp
+)
 
 # package
 set(LLVMDEP "libllvm${LLVMVersion}")

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ FROM ubuntu:24.04 AS executable
 COPY --from=build /work/build/golfC-1.1.1-Linux.deb /
 RUN apt-get update && \
     apt install /golfC-1.1.1-Linux.deb clang-17 -y
-ENTRYPOINT [ "minifier", "--", "-I", "/usr/lib/clang/17/include" ]
+ENTRYPOINT [ "minifier", "--", "-I", "/usr/lib/clang/17/include", "-Wno-null-character" ]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Note: as of now, you must provide the include directories as extra arguments to 
 For instance:
 
 ```sh
-minifier myFile.c -- -I /usr/lib/clang/17/include
+minifier myFile.c -- -I /usr/lib/clang/17/include -Wno-null-character
 ```
 
 ## Features

--- a/examples/macros/main.c
+++ b/examples/macros/main.c
@@ -5,9 +5,12 @@
 #define f(a) printf( \
     "hi %s\n", #a)
 #define g (a)
+#define myVar b + c
 void print_int(int num)
 {
-    printf("Got int %d\n", num);
+    int b = 3;
+    int c = 4;
+    printf("Got int %d\n", num + myVar);
 }
 int main()
 {
@@ -18,13 +21,14 @@ int main()
     int gf = 31;
 #endif
 
+    int c = 3;
     print_int g;
 #define d
-    printf("a+b = %d\n", a + b);
+    printf("a+b = %d\n", a);
     for (int i = 0; i < 10; ++i)
     {
         int tmp = i * i;
         int last = tmp * tmp;
-        printf("hello %d\n", last);
+        printf("hello %d\n", last + myVar);
     }
 }

--- a/examples/macros/main.c
+++ b/examples/macros/main.c
@@ -1,4 +1,6 @@
+#include <fcntl.h>
 #include <stdio.h>
+#include <unistd.h>
 #define a 324
 #define f(a) printf( \
     "hi %s\n", #a)
@@ -10,6 +12,12 @@ void print_int(int num)
 int main()
 {
     int b = 3; // this is a comment
+#ifdef O_APPEND
+    int f = O_APPEND;
+#else
+    int gf = 31;
+#endif
+
     print_int g;
 #define d
     printf("a+b = %d\n", a + b);

--- a/include/actions/expandMacroAction.hpp
+++ b/include/actions/expandMacroAction.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include <clang/Tooling/Tooling.h>
+#include <clang/Frontend/FrontendActions.h>
+#include <clang/Tooling/Core/Replacement.h>
+#include <memory>
+
+class ExpandMacroAction : public clang::PreprocessOnlyAction
+{
+private:
+    clang::tooling::Replacements *replacements;
+
+public:
+    ExpandMacroAction(clang::tooling::Replacements *replacements);
+    virtual void ExecuteAction() override;
+    static std::unique_ptr<clang::tooling::FrontendActionFactory> newExpandMacroAction(clang::tooling::Replacements *replacements);
+};

--- a/src/actions/expandMacroAction.cpp
+++ b/src/actions/expandMacroAction.cpp
@@ -1,0 +1,100 @@
+#include <actions/expandMacroAction.hpp>
+#include <clang/AST/ASTConsumer.h>
+#include <clang/AST/RecursiveASTVisitor.h>
+#include <clang/Frontend/CompilerInstance.h>
+#include <clang/Frontend/FrontendAction.h>
+#include <clang/Frontend/FrontendActions.h>
+#include <clang/Tooling/CommonOptionsParser.h>
+#include <clang/Tooling/Tooling.h>
+#include <clang/Lex/MacroArgs.h>
+#include <llvm/Support/CommandLine.h>
+#include <clang/Lex/PreprocessorOptions.h>
+#include <clang/Rewrite/Core/Rewriter.h>
+#include <clang/Lex/Preprocessor.h>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+using namespace std;
+using namespace clang;
+using namespace clang::tooling;
+using namespace llvm;
+
+class IncludePPCallbacks : public PPCallbacks
+{
+private:
+    SourceManager &manager;
+    ostringstream &ss;
+
+public:
+    IncludePPCallbacks(SourceManager &manager, ostringstream &ss) : manager(manager), ss(ss) {};
+    virtual void InclusionDirective(SourceLocation HashLoc,
+                                    const Token &IncludeTok, StringRef FileName,
+                                    bool IsAngled, CharSourceRange FilenameRange,
+                                    OptionalFileEntryRef File,
+                                    StringRef SearchPath, StringRef RelativePath,
+                                    const Module *Imported,
+                                    SrcMgr::CharacteristicKind FileType)
+    {
+        if (manager.isWrittenInMainFile(FilenameRange.getAsRange().getBegin()))
+        {
+            if (IsAngled)
+            {
+                ss << "#include<" << FileName.str() << ">\n";
+            }
+            else
+            {
+                ss << "#include\"" << FileName.str() << "\"\n";
+            }
+        }
+    }
+};
+
+void process(SourceManager &sm, Preprocessor &preproc, Replacements *r)
+{
+    // preparation
+    ostringstream o;
+    preproc.addPPCallbacks(make_unique<IncludePPCallbacks>(sm, o));
+    preproc.EnterMainSourceFile();
+
+    // main loop
+    Token tok;
+    preproc.Lex(tok);
+    while (!tok.is(tok::eof))
+    {
+        SourceLocation fileLoc = sm.getFileLoc(tok.getLocation());
+        if (sm.getFileID(fileLoc) == sm.getMainFileID())
+        {
+            o << preproc.getSpelling(tok) << "\n";
+        }
+        preproc.Lex(tok);
+    }
+
+    // output
+    string output = o.str();
+    SourceLocation mainFileBegin = sm.getLocForStartOfFile(sm.getMainFileID());
+    SourceLocation mainFileEnd = sm.getLocForEndOfFile(sm.getMainFileID());
+    SourceRange mainFileRange(mainFileBegin, mainFileEnd);
+    cantFail(r->add(Replacement(sm, CharSourceRange::getCharRange(mainFileRange), output)));
+}
+void ExpandMacroAction::ExecuteAction()
+{
+    CompilerInstance &compiler = getCompilerInstance();
+    process(compiler.getSourceManager(), compiler.getPreprocessor(), replacements);
+}
+ExpandMacroAction::ExpandMacroAction(Replacements *replacements) : replacements(replacements) {}
+unique_ptr<FrontendActionFactory> ExpandMacroAction::newExpandMacroAction(Replacements *replacements)
+{
+    class Adapter : public FrontendActionFactory
+    {
+    private:
+        Replacements *replacements;
+
+    public:
+        Adapter(Replacements *replacements) : replacements(replacements) {};
+        virtual unique_ptr<FrontendAction> create() override
+        {
+            return make_unique<ExpandMacroAction>(replacements);
+        }
+    };
+    return make_unique<Adapter>(replacements);
+}

--- a/src/actions/expandMacroAction.cpp
+++ b/src/actions/expandMacroAction.cpp
@@ -39,11 +39,11 @@ public:
         {
             if (IsAngled)
             {
-                ss << "#include<" << FileName.str() << ">\n";
+                ss << "\n#include<" << FileName.str() << ">\n";
             }
             else
             {
-                ss << "#include\"" << FileName.str() << "\"\n";
+                ss << "\n#include\"" << FileName.str() << "\"\n";
             }
         }
     }
@@ -64,17 +64,16 @@ void process(SourceManager &sm, Preprocessor &preproc, Replacements *r)
         SourceLocation fileLoc = sm.getFileLoc(tok.getLocation());
         if (sm.getFileID(fileLoc) == sm.getMainFileID())
         {
-            o << preproc.getSpelling(tok) << "\n";
+            o << preproc.getSpelling(tok) << " ";
         }
         preproc.Lex(tok);
     }
 
     // output
-    string output = o.str();
     SourceLocation mainFileBegin = sm.getLocForStartOfFile(sm.getMainFileID());
-    SourceLocation mainFileEnd = sm.getLocForEndOfFile(sm.getMainFileID());
-    SourceRange mainFileRange(mainFileBegin, mainFileEnd);
-    cantFail(r->add(Replacement(sm, CharSourceRange::getCharRange(mainFileRange), output)));
+    SourceLocation mainFileEnd = tok.getLocation();
+    const CharSourceRange &mainFileRange = CharSourceRange::getCharRange(SourceRange(mainFileBegin, mainFileEnd));
+    cantFail(r->add(Replacement(sm, mainFileRange, o.str())));
 }
 void ExpandMacroAction::ExecuteAction()
 {

--- a/src/ciexplorer.cpp
+++ b/src/ciexplorer.cpp
@@ -1,0 +1,113 @@
+#include <clang/AST/ASTConsumer.h>
+#include <clang/AST/RecursiveASTVisitor.h>
+#include <clang/Frontend/CompilerInstance.h>
+#include <clang/Frontend/FrontendAction.h>
+#include <clang/Frontend/FrontendActions.h>
+#include <clang/Tooling/CommonOptionsParser.h>
+#include <clang/Tooling/Tooling.h>
+#include <clang/Lex/MacroArgs.h>
+#include <llvm/Support/CommandLine.h>
+#include <clang/Lex/PreprocessorOptions.h>
+#include <clang/Lex/Preprocessor.h>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+using namespace std;
+using namespace clang;
+using namespace clang::tooling;
+using namespace llvm;
+
+class IncludePPCallbacks : public PPCallbacks
+{
+private:
+    SourceManager &manager;
+
+public:
+    IncludePPCallbacks(SourceManager &manager) : manager(manager) {};
+    virtual void InclusionDirective(SourceLocation HashLoc,
+                                    const Token &IncludeTok, StringRef FileName,
+                                    bool IsAngled, CharSourceRange FilenameRange,
+                                    OptionalFileEntryRef File,
+                                    StringRef SearchPath, StringRef RelativePath,
+                                    const Module *Imported,
+                                    SrcMgr::CharacteristicKind FileType)
+    {
+        if (manager.isWrittenInMainFile(FilenameRange.getAsRange().getBegin()))
+        {
+            outs() << "got an include for " << FileName << " isangled: " << IsAngled << "\n";
+        }
+    }
+};
+
+void process(SourceManager &sm, Preprocessor &preproc)
+{
+    // create a copy of the preprocessor
+    // LangOptions langOpts(originalPreproc.getLangOpts());
+    // shared_ptr<HeaderSearchOptions> hSearchOptions = make_shared<HeaderSearchOptions>(originalPreproc.getHeaderSearchInfo().getHeaderSearchOpts());
+    // HeaderSearch hSearch(hSearchOptions, originalPreproc.getSourceManager(), originalPreproc.getDiagnostics(), langOpts, &originalPreproc.getTargetInfo());
+    // shared_ptr<PreprocessorOptions> procOptions = make_shared<PreprocessorOptions>(originalPreproc.getPreprocessorOpts());
+    // Preprocessor preproc(procOptions, originalPreproc.getDiagnostics(), langOpts, originalPreproc.getSourceManager(), hSearch, originalPreproc.getModuleLoader());
+    // preproc.Initialize(originalPreproc.getTargetInfo(), originalPreproc.getAuxTargetInfo());
+    // ApplyHeaderSearchOptions(hSearch, *hSearchOptions,
+    //                          langOpts, originalPreproc.getTargetInfo().getTriple());
+    // outs() << originalPreproc.getTargetInfo().getTriple().str() << "\n";
+
+    // main stuff
+    preproc.addPPCallbacks(make_unique<IncludePPCallbacks>(sm));
+    preproc.EnterMainSourceFile();
+    Token tok;
+    preproc.Lex(tok);
+    SourceLocation prevLocation = sm.getLocForStartOfFile(sm.getMainFileID());
+
+    while (!tok.is(tok::eof))
+    {
+        SourceLocation fileLoc = sm.getFileLoc(tok.getLocation());
+        if (sm.getFileID(fileLoc) == sm.getMainFileID())
+        {
+            outs() << "got token " << tok.getName() << " " << preproc.getSpelling(tok) << "\n";
+        }
+        preproc.Lex(tok);
+    }
+    preproc.PrintStats();
+}
+
+class ExplorerAction : public clang::PreprocessOnlyAction
+{
+public:
+    virtual void ExecuteAction() override
+    {
+        CompilerInstance &compiler = getCompilerInstance();
+        process(compiler.getSourceManager(), compiler.getPreprocessor());
+    }
+};
+
+// Apply a custom category to all command-line options so that they are the
+// only ones displayed.
+static cl::OptionCategory MyToolCategory("my-tool options");
+
+// CommonOptionsParser declares HelpMessage with a description of the common
+// command-line options related to the compilation database and input files.
+// It's nice to have this help message in all tools.
+static cl::extrahelp CommonHelp(CommonOptionsParser::HelpMessage);
+
+// A help message for this specific tool can be added afterwards.
+static cl::extrahelp MoreHelp("\nMore help text...\n");
+
+int main(int argc, const char **argv)
+{
+    auto ExpectedParser = CommonOptionsParser::create(argc, argv, MyToolCategory);
+    if (!ExpectedParser)
+    {
+        llvm::errs() << ExpectedParser.takeError();
+        return 1;
+    }
+    CommonOptionsParser &OptionsParser = ExpectedParser.get();
+    ClangTool Tool(OptionsParser.getCompilations(),
+                   OptionsParser.getSourcePathList());
+    for (const auto &source : OptionsParser.getSourcePathList())
+    {
+        cout << "Examining " << source << endl;
+    }
+
+    return Tool.run(newFrontendActionFactory<ExplorerAction>().get());
+}


### PR DESCRIPTION
* Add option to expand all macros, which results in safer replacement than not expanding all macros
  * Previously, if a macro body was used to reference different variables, this could result in an error; expanding all macros fixes this issue